### PR TITLE
Check if the dist_tolerance parameter already exists before declaring it

### DIFF
--- a/.github/workflows/jazzy.yaml
+++ b/.github/workflows/jazzy.yaml
@@ -53,3 +53,4 @@ jobs:
           vcs-repo-file-url: /tmp/deps.repos
           target-ros2-distro: jazzy
           skip-tests: true
+          rosdep-skip-keys: lvr2

--- a/mesh_mppi/src/scoring/XTECostFunction.cpp
+++ b/mesh_mppi/src/scoring/XTECostFunction.cpp
@@ -64,7 +64,9 @@ XTECostFunction::XTECostFunction(
     }
 
     // Read the mbf dist_tolerance
-    node->declare_parameter<double>("dist_tolerance");
+    if (!node->has_parameter("dist_tolerance")) {
+        node->declare_parameter<double>("dist_tolerance");
+    }
     goal_tolerance_ = node->get_parameter("dist_tolerance").as_double();
 
     // Read the controller map_cost_limit


### PR DESCRIPTION
This fixes a crash if multiple mesh_mppi controllers are configured in one `mesh_navigation` instance